### PR TITLE
Optimized `remove_small_cells`

### DIFF
--- a/src/cvstitch.py
+++ b/src/cvstitch.py
@@ -179,10 +179,8 @@ class CVMaskStitcher():
 
     # Remove any cells smaller than the defined threshold.
     def remove_small_cells(self, mask):
-        mask_id, sizes = np.unique(mask, return_counts = True)
-        keep_indices = list(sizes > self.threshold)
-        for currid, keep_id in zip(mask_id, keep_indices):
-            if not keep_id:
-                mask[mask == currid] = 0
-
-        return mask, list(sizes[keep_indices]), list(mask_id[keep_indices])
+        mask_id, sizes = np.unique(mask, return_counts=True)
+        keep_indices = sizes > self.threshold
+        keep_ids = mask_id[keep_indices]
+        mask[np.isin(mask, keep_ids, invert=True)] = 0
+        return mask, sizes[keep_indices].tolist(), keep_ids.tolist()


### PR DESCRIPTION
Now creates a boolean mask of cells with sizes above the threshold using sizes > self.threshold, and then uses np.isin() with the invert=True option to create a mask of cells that should be set to zero. Finally, it sets those cells to zero in the original mask array using boolean indexing.